### PR TITLE
Set up development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+`skovhus.dev` is a static Next.js 14 (App Router) personal site/blog. Content lives in `content/` and is compiled by Contentlayer (`contentlayer.config.ts`) into `.contentlayer/`. There is no backend, database, or external service.
+
+Standard commands are in `package.json` (`dev`, `build`, `start`, `lint`, `typecheck`, `verify`) and CI runs in `.github/workflows/verify.yml`.
+
+Non-obvious notes:
+
+- `pnpm dev` serves on http://localhost:3000 and regenerates Contentlayer docs on startup; the first request can be slow due to on-demand compilation.
+- `pnpm lint` runs `prettier --write` (not `--check`), so it reformats files in place across the repo. Use `git checkout -- .` afterward to drop unrelated formatting changes you did not intend.
+- `pnpm install` reports ignored build scripts (`contentlayer2`, `esbuild`, `protobufjs`); this is expected and matches CI (`--ignore-scripts`). Build, dev, and `verify` all work without approving them.
+- `pnpm verify` (`contentlayer2 build && pnpm lint && pnpm typecheck`) is the full check; run it before pushing.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for `skovhus.dev` (a static Next.js 14 + Contentlayer personal blog). No application code changed.

- Installed dependencies with `pnpm install --frozen-lockfile` (Node 22, pnpm 10, matching CI).
- Verified lint, typecheck, and content build via `pnpm verify`.
- Ran the dev server (`pnpm dev`) and confirmed the site renders end-to-end.
- Added `AGENTS.md` with Cursor Cloud specific instructions (durable, non-obvious notes only).

## Walkthrough

[skovhus_blog_demo.mp4](https://cursor.com/agents/bc-cd623684-8e1d-4624-92cb-3977b5b5cec3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fskovhus_blog_demo.mp4)

Homepage, blog index, and a full blog post with syntax-highlighted code all render correctly.

[Homepage](https://cursor.com/agents/bc-cd623684-8e1d-4624-92cb-3977b5b5cec3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage.webp)
[Rendered blog post](https://cursor.com/agents/bc-cd623684-8e1d-4624-92cb-3977b5b5cec3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_post.webp)

## Testing

- ✅ `pnpm install --frozen-lockfile`
- ✅ `pnpm verify` (`contentlayer2 build && pnpm lint && pnpm typecheck`)
- ✅ `pnpm dev` + manual browser navigation (home `200`, `/blog` `200`, blog post renders)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd623684-8e1d-4624-92cb-3977b5b5cec3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd623684-8e1d-4624-92cb-3977b5b5cec3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

