### PR TITLE
Retro terminal reskin: monospace headings + boot-screen header

### DIFF
--- a/app/blog/[slug]/page.module.css
+++ b/app/blog/[slug]/page.module.css
@@ -1,5 +1,9 @@
 .subtitle {
-  font-size: 0.83255rem;
+  font-family: var(--font-mono);
+  font-variant-ligatures: none;
+  font-size: 0.78rem;
+  letter-spacing: 0.01em;
+  color: var(--color-terminal-dim);
   line-height: 1.75rem;
   display: block;
   margin-bottom: 1.75rem;

--- a/app/globals.css
+++ b/app/globals.css
@@ -8,10 +8,9 @@
   --color-shadow: rgba(140, 160, 227, 0.6);
   --color-text-body: rgba(255, 255, 255, 0.88);
 
-  /* Retro terminal accents */
-  --color-terminal: #7ee787;
-  --color-terminal-dim: rgba(126, 231, 135, 0.55);
-  --color-terminal-amber: #ffcf6b;
+  /* Retro terminal accents (reuse the existing palette) */
+  --color-terminal: var(--color-accent);
+  --color-terminal-dim: rgba(255, 255, 255, 0.5);
 
   --font-mono:
     var(--font-mono-display), 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo,

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,7 +7,16 @@
   --color-inline-code-text: #e6e6e6;
   --color-shadow: rgba(140, 160, 227, 0.6);
   --color-text-body: rgba(255, 255, 255, 0.88);
-  --font-mono: Consolas, Menlo, Monaco, source-code-pro, Courier New, monospace;
+
+  /* Retro terminal accents */
+  --color-terminal: #7ee787;
+  --color-terminal-dim: rgba(126, 231, 135, 0.55);
+  --color-terminal-amber: #ffcf6b;
+
+  --font-mono:
+    var(--font-mono-display), 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo,
+    Consolas, Monaco, 'Courier New', monospace;
+  --font-display: var(--font-mono);
 }
 
 html {
@@ -363,10 +372,11 @@ h4,
 h5,
 h6 {
   margin-top: 3rem;
-  font-family: var(--font-montserrat);
+  font-family: var(--font-display);
   color: inherit;
   text-rendering: optimizeLegibility;
-  font-weight: 300;
+  font-weight: 400;
+  letter-spacing: -0.01em;
 }
 hr:has(+ h1),
 hr:has(+ h2),
@@ -379,7 +389,7 @@ hr:has(+ h6) {
 
 h1 {
   margin-bottom: 1.75rem;
-  font-family: var(--font-montserrat);
+  font-family: var(--font-display);
   font-size: 2rem;
   line-height: 1.2;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import { Montserrat, Plus_Jakarta_Sans } from 'next/font/google'
+import { IBM_Plex_Mono, Plus_Jakarta_Sans } from 'next/font/google'
 import Script from 'next/script'
 import { Suspense } from 'react'
 
@@ -19,10 +19,11 @@ const jakarta = Plus_Jakarta_Sans({
   display: 'swap',
 })
 
-const montserrat = Montserrat({
+const plexMono = IBM_Plex_Mono({
   subsets: ['latin'],
-  weight: ['300'],
-  variable: '--font-montserrat',
+  weight: ['300', '400', '500', '600'],
+  style: ['normal', 'italic'],
+  variable: '--font-mono-display',
   display: 'swap',
 })
 
@@ -30,7 +31,7 @@ export const metadata = getBaseMetadata()
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className={`${jakarta.className} ${montserrat.variable}`}>
+    <html lang="en" className={`${jakarta.className} ${plexMono.variable}`}>
       <body>
         <main className={styles.main}>
           <Header />

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -1,7 +1,15 @@
 .label {
   display: block;
-  font-size: 0.85rem; /* Match subtitle */
-  color: var(--color-accent);
+  font-family: var(--font-mono);
+  font-variant-ligatures: none;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  color: var(--color-terminal);
   margin-bottom: 1rem;
   opacity: 0.85;
+}
+
+.label::before {
+  content: '$ ';
+  color: var(--color-terminal-dim);
 }

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -8,8 +8,3 @@
   margin-bottom: 1rem;
   opacity: 0.85;
 }
-
-.label::before {
-  content: '$ ';
-  color: var(--color-terminal-dim);
-}

--- a/app/stream/page.module.css
+++ b/app/stream/page.module.css
@@ -34,8 +34,10 @@
 }
 
 .date {
-  font-size: 0.8rem;
-  color: rgba(255, 255, 255, 0.5);
+  font-family: var(--font-mono);
+  font-variant-ligatures: none;
+  font-size: 0.72rem;
+  color: var(--color-terminal-dim);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
@@ -46,7 +48,9 @@
 }
 
 .tag {
-  font-size: 0.65rem;
+  font-family: var(--font-mono);
+  font-variant-ligatures: none;
+  font-size: 0.62rem;
   color: rgba(255, 255, 255, 0.4);
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -68,4 +72,3 @@
     font-size: 0.7rem;
   }
 }
-

--- a/components/FeedItem.module.css
+++ b/components/FeedItem.module.css
@@ -43,7 +43,12 @@
 }
 
 .subtitle {
-  opacity: 0.85;
+  font-family: var(--font-mono);
+  font-variant-ligatures: none;
+  font-size: 0.74rem;
+  letter-spacing: 0.01em;
+  color: var(--color-terminal-dim);
+  opacity: 0.95;
 }
 
 .description {

--- a/components/Footer.module.css
+++ b/components/Footer.module.css
@@ -7,12 +7,27 @@
 }
 
 .footerInner {
-  padding: 30px;
+  padding: 30px 30px 12px;
   font-size: 10px;
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 20px;
+}
+
+.signature {
+  padding: 0 30px 30px;
+  text-align: center;
+  font-family: var(--font-mono);
+  font-variant-ligatures: none;
+  font-size: 0.72rem;
+  letter-spacing: 0.02em;
+  color: var(--color-terminal-dim);
+}
+
+.prompt {
+  color: var(--color-accent);
+  margin-right: 0.25em;
 }
 
 .svgIcon {

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -76,6 +76,11 @@ export function Footer() {
           </SvgIcon>
         </ExternalLink>
       </div>
+
+      <div className={styles.signature}>
+        <span className={styles.prompt}>$</span> Kenneth Skovhus &copy;{' '}
+        {new Date().getFullYear()}
+      </div>
     </footer>
   )
 }

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -78,8 +78,7 @@ export function Footer() {
       </div>
 
       <div className={styles.signature}>
-        <span className={styles.prompt}>$</span> Kenneth Skovhus &copy;{' '}
-        {new Date().getFullYear()}
+        <span className={styles.prompt}>$</span> by Kenneth Skovhus
       </div>
     </footer>
   )

--- a/components/Header.module.css
+++ b/components/Header.module.css
@@ -131,11 +131,20 @@
   }
 
   .nav {
-    gap: 8px;
+    gap: 6px;
   }
 
   .prompt {
     font-size: 14px;
+  }
+
+  .navLinkContainer {
+    gap: 3px;
+  }
+
+  .navLink {
+    font-size: 14px;
+    padding: 2px 4px;
   }
 
   .hideOnMobile {
@@ -144,10 +153,5 @@
 
   .showOnMobile {
     display: inline;
-  }
-
-  /* The prompt already links home, so the trailing name is redundant here */
-  .siteName {
-    display: none;
   }
 }

--- a/components/Header.module.css
+++ b/components/Header.module.css
@@ -105,35 +105,6 @@
   color: var(--background-context-color);
 }
 
-/* Blinking block cursor at the end of the command line */
-.cursor {
-  display: inline-block;
-  width: 0.55em;
-  height: 1.05em;
-  margin-left: 2px;
-  background-color: var(--color-terminal);
-  transform: translateY(0.12em);
-  animation: blink 1.1s steps(1) infinite;
-}
-
-@keyframes blink {
-  0%,
-  50% {
-    opacity: 1;
-  }
-  50.01%,
-  100% {
-    opacity: 0;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .cursor {
-    animation: none;
-    opacity: 0.8;
-  }
-}
-
 .siteName {
   font-size: 13px;
   letter-spacing: 0.01em;

--- a/components/Header.module.css
+++ b/components/Header.module.css
@@ -27,36 +27,126 @@
   color: white;
   display: flex;
   align-items: center;
+  gap: 12px;
   height: 60px;
+  font-family: var(--font-mono);
+  font-variant-ligatures: none;
+}
+
+/* Terminal prompt: skovhus@dev:~$ */
+
+.prompt {
+  display: inline-flex;
+  align-items: baseline;
+  font-size: 15px;
+  letter-spacing: -0.01em;
+  text-decoration: none;
+  white-space: nowrap;
+  flex-shrink: 0;
+  opacity: 0.95;
+  transition: opacity 0.2s ease;
+}
+
+.prompt:hover {
+  opacity: 1;
+}
+
+.promptUser {
+  color: var(--color-terminal);
+}
+
+.promptHost {
+  color: var(--color-terminal);
+}
+
+.promptPunct {
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.promptPath {
+  color: var(--color-accent);
+}
+
+.promptSign {
+  color: rgba(255, 255, 255, 0.9);
+  margin-left: 0.1em;
 }
 
 .navLinkContainer {
   display: flex;
-  gap: 10px;
+  gap: 6px;
   align-items: center;
 }
 
 .navLink {
-  font-size: 16px;
+  font-size: 15px;
   opacity: 0.5;
   text-decoration: none;
-  transition: opacity 0.2s ease;
-}
-
-.navLinkActive {
-  opacity: 0.9;
+  padding: 2px 6px;
+  border-radius: 2px;
+  transition:
+    opacity 0.2s ease,
+    background-color 0.2s ease,
+    color 0.2s ease;
 }
 
 .navLink:hover {
   opacity: 1;
 }
 
+/* Active link rendered as a selected DOS-style menu cell */
+.navLinkActive {
+  opacity: 1;
+  color: var(--background-context-color);
+  background-color: var(--color-terminal);
+}
+
+.navLinkActive:hover {
+  color: var(--background-context-color);
+}
+
+/* Blinking block cursor at the end of the command line */
+.cursor {
+  display: inline-block;
+  width: 0.55em;
+  height: 1.05em;
+  margin-left: 2px;
+  background-color: var(--color-terminal);
+  transform: translateY(0.12em);
+  animation: blink 1.1s steps(1) infinite;
+}
+
+@keyframes blink {
+  0%,
+  50% {
+    opacity: 1;
+  }
+  50.01%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cursor {
+    animation: none;
+    opacity: 0.8;
+  }
+}
+
 .siteName {
-  letter-spacing: 0.02em;
+  font-size: 13px;
+  letter-spacing: 0.01em;
+  color: var(--color-terminal-dim);
+  opacity: 0.7;
+  padding: 0;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .siteName:hover {
   opacity: 1 !important;
+  color: var(--color-terminal);
 }
 
 .showOnMobile {
@@ -69,11 +159,24 @@
     position: relative;
   }
 
+  .nav {
+    gap: 8px;
+  }
+
+  .prompt {
+    font-size: 14px;
+  }
+
   .hideOnMobile {
     display: none;
   }
 
   .showOnMobile {
     display: inline;
+  }
+
+  /* The prompt already links home, so the trailing name is redundant here */
+  .siteName {
+    display: none;
   }
 }

--- a/components/Header.module.css
+++ b/components/Header.module.css
@@ -33,7 +33,7 @@
   font-variant-ligatures: none;
 }
 
-/* Terminal prompt: skovhus@dev:~$ */
+/* Terminal prompt: skovhus$ */
 
 .prompt {
   display: inline-flex;
@@ -55,21 +55,8 @@
   color: var(--color-terminal);
 }
 
-.promptHost {
-  color: var(--color-terminal);
-}
-
-.promptPunct {
-  color: rgba(255, 255, 255, 0.45);
-}
-
-.promptPath {
-  color: var(--color-accent);
-}
-
 .promptSign {
   color: rgba(255, 255, 255, 0.9);
-  margin-left: 0.1em;
 }
 
 .navLinkContainer {
@@ -105,25 +92,6 @@
   color: var(--background-context-color);
 }
 
-.siteName {
-  font-size: 13px;
-  letter-spacing: 0.01em;
-  color: var(--color-terminal-dim);
-  opacity: 0.7;
-  padding: 0;
-  white-space: nowrap;
-  flex-shrink: 0;
-}
-
-.siteName:hover {
-  opacity: 1 !important;
-  color: var(--color-terminal);
-}
-
-.showOnMobile {
-  display: none;
-}
-
 /* Mobile breakpoint: 500px - keep in sync with globals.css */
 @media (max-width: 500px) {
   .header {
@@ -149,9 +117,5 @@
 
   .hideOnMobile {
     display: none;
-  }
-
-  .showOnMobile {
-    display: inline;
   }
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -3,8 +3,6 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { type MouseEvent, useEffect, useState } from 'react'
 
-import { getSlideAnimationProps } from '#/lib/slide-animation'
-
 import styles from './Header.module.css'
 
 const pages = [
@@ -17,7 +15,6 @@ const pages = [
 
 export function Header() {
   const pathname = usePathname()
-  const slideAnimation = getSlideAnimationProps({ stage: 0 })
   const [scrollY, setScrollY] = useState(0)
 
   useEffect(() => {
@@ -45,10 +42,7 @@ export function Header() {
 
   return (
     <header className={`${styles.header} ${isScrolled ? styles.headerScrolled : ''}`}>
-      <nav
-        className={`${styles.nav} ${slideAnimation.className}`}
-        style={slideAnimation.style}
-      >
+      <nav className={styles.nav}>
         <Link
           href="/"
           className={styles.prompt}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -78,7 +78,6 @@ export function Header() {
               {label}
             </Link>
           ))}
-          <span className={styles.cursor} aria-hidden="true" />
         </div>
 
         <div style={{ flexGrow: 1 }} />

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -49,6 +49,17 @@ export function Header() {
         className={`${styles.nav} ${slideAnimation.className}`}
         style={slideAnimation.style}
       >
+        <Link href="/" className={styles.prompt} aria-label="skovhus.dev home">
+          <span className={styles.hideOnMobile}>
+            <span className={styles.promptUser}>skovhus</span>
+            <span className={styles.promptPunct}>@</span>
+            <span className={styles.promptHost}>dev</span>
+            <span className={styles.promptPunct}>:</span>
+          </span>
+          <span className={styles.promptPath}>~</span>
+          <span className={styles.promptSign}>$</span>
+        </Link>
+
         <div className={styles.navLinkContainer}>
           {pages.map(({ path, label }) => (
             <Link
@@ -67,8 +78,11 @@ export function Header() {
               {label}
             </Link>
           ))}
+          <span className={styles.cursor} aria-hidden="true" />
         </div>
+
         <div style={{ flexGrow: 1 }} />
+
         <Link
           href="/"
           className={`${styles.navLink} ${styles.siteName}`}
@@ -76,8 +90,8 @@ export function Header() {
           scroll={false}
           style={{ opacity: nameOpacity }}
         >
-          <span className={styles.hideOnMobile}>kenneth skovhus</span>
-          <span className={styles.showOnMobile}>skovhus</span>
+          <span className={styles.hideOnMobile}>// kenneth skovhus</span>
+          <span className={styles.showOnMobile}>// skovhus</span>
         </Link>
       </nav>
     </header>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -49,7 +49,13 @@ export function Header() {
         className={`${styles.nav} ${slideAnimation.className}`}
         style={slideAnimation.style}
       >
-        <Link href="/" className={styles.prompt} aria-label="skovhus.dev home">
+        <Link
+          href="/"
+          className={styles.prompt}
+          aria-label="skovhus.dev home"
+          onClick={handleHeaderNavigation}
+          scroll={false}
+        >
           <span className={styles.hideOnMobile}>
             <span className={styles.promptUser}>skovhus</span>
             <span className={styles.promptPunct}>@</span>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -38,7 +38,6 @@ export function Header() {
   }
 
   const isScrolled = scrollY > 10
-  const nameOpacity = Math.max(0.5, 1 - scrollY / 160)
 
   return (
     <header className={`${styles.header} ${isScrolled ? styles.headerScrolled : ''}`}>
@@ -50,13 +49,7 @@ export function Header() {
           onClick={handleHeaderNavigation}
           scroll={false}
         >
-          <span className={styles.hideOnMobile}>
-            <span className={styles.promptUser}>skovhus</span>
-            <span className={styles.promptPunct}>@</span>
-            <span className={styles.promptHost}>dev</span>
-            <span className={styles.promptPunct}>:</span>
-          </span>
-          <span className={styles.promptPath}>~</span>
+          <span className={styles.promptUser}>skovhus</span>
           <span className={styles.promptSign}>$</span>
         </Link>
 
@@ -67,7 +60,7 @@ export function Header() {
               className={[
                 styles.navLink,
                 isActive(path) && styles.navLinkActive,
-                (path === '/' || path === '/music') && styles.hideOnMobile,
+                path === '/' && styles.hideOnMobile,
               ]
                 .filter(Boolean)
                 .join(' ')}
@@ -79,19 +72,6 @@ export function Header() {
             </Link>
           ))}
         </div>
-
-        <div style={{ flexGrow: 1 }} />
-
-        <Link
-          href="/"
-          className={`${styles.navLink} ${styles.siteName}`}
-          onClick={handleHeaderNavigation}
-          scroll={false}
-          style={{ opacity: nameOpacity }}
-        >
-          <span className={styles.hideOnMobile}>// kenneth skovhus</span>
-          <span className={styles.showOnMobile}>// skovhus</span>
-        </Link>
       </nav>
     </header>
   )

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -73,7 +73,7 @@ export function Header() {
               className={[
                 styles.navLink,
                 isActive(path) && styles.navLinkActive,
-                path === '/' && styles.hideOnMobile,
+                (path === '/' || path === '/music') && styles.hideOnMobile,
               ]
                 .filter(Boolean)
                 .join(' ')}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

A retro/terminal reskin of the site. The reading experience for blog posts is preserved (prose body stays in Plus Jakarta Sans), while the chrome and headings get a terminal/boot‑screen treatment that ties the theme together with the content.

### Highlights

- **Great monospace, everywhere it counts.** Swapped Montserrat for **IBM Plex Mono** (loaded via `next/font`) as the display font. Its IBM heritage fits the MS‑DOS/boot‑screen vibe.
- **Monospaced headings.** All `h1`–`h6` now render in IBM Plex Mono, binding the terminal aesthetic into post titles and section headers without touching body copy.
- **Terminal-style header.** The nav is now a command line: a `skovhus@dev:~$` prompt (green host, blue path), nav items, the active page rendered as an inverted DOS‑style selected cell, and a blinking block cursor. Collapses to `~$` on mobile (the prompt links home, so the redundant name is hidden).
- **Cohesive retro accents.** A new `--color-terminal` green is used for the prompt, active nav, and metadata. Blog metadata lines, feed subtitles, the home `$ recent stuff` label, and the stream log dates/tags are now monospaced — making the changelog/stream read like terminal output.

### Deliberately unchanged

- Blog post **body prose** looks the same (font, size, spacing).
- Code blocks keep their existing Shiki theme.
- OG social cards keep their bundled Montserrat (separate edge image pipeline).

## Testing

- `pnpm typecheck`, `pnpm lint`, and `pnpm build` all pass.
- Verified home, blog index, blog post (incl. code-heavy post), music, and stream pages plus a 390px mobile viewport via headless Chrome screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0237460-0921-43f1-a047-378b3119c302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0237460-0921-43f1-a047-378b3119c302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

