### PR TITLE
Nostalgia design

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -7,7 +7,15 @@
   --color-inline-code-text: #e6e6e6;
   --color-shadow: rgba(140, 160, 227, 0.6);
   --color-text-body: rgba(255, 255, 255, 0.88);
+  /* Nods to 90s point-and-click adventures: SCUMM verb green and dialog purple */
+  --color-verb: rgb(140, 220, 150);
+  --color-dialog: rgb(180, 120, 200);
   --font-mono: Consolas, Menlo, Monaco, source-code-pro, Courier New, monospace;
+}
+
+::selection {
+  background: var(--color-dialog);
+  color: rgb(255, 255, 255);
 }
 
 html {
@@ -60,8 +68,8 @@ a:active {
   text-decoration-color: var(--color-accent);
 }
 a:focus-visible {
-  outline: var(--color-accent) solid 2px;
-  border-radius: 1px;
+  outline: 2px dotted var(--color-accent);
+  border-radius: 0;
 }
 figure a,
 h1 a,
@@ -93,13 +101,14 @@ h4 a {
   overflow-x: auto;
 }
 
+/* Square corners, like a DOS-era dialog box */
 .prose :not(pre) > code,
 .prose pre {
   border-style: solid;
   border-width: 1px;
-  border-color: rgb(38, 38, 38);
+  border-color: rgb(48, 52, 64);
   background-color: var(--color-inline-code-background) !important;
-  border-radius: 0.5rem;
+  border-radius: 0;
 }
 
 pre::-webkit-scrollbar {
@@ -128,8 +137,8 @@ pre::-webkit-scrollbar {
 }
 
 [data-rehype-pretty-code-title] {
-  border-top-left-radius: 0.5rem;
-  border-top-right-radius: 0.5rem;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
   border-width: 1px;
   border-style: solid;
   border-color: rgb(51, 51, 51);
@@ -363,10 +372,11 @@ h4,
 h5,
 h6 {
   margin-top: 3rem;
-  font-family: var(--font-montserrat);
+  font-family: var(--font-pixel);
   color: inherit;
   text-rendering: optimizeLegibility;
-  font-weight: 300;
+  font-weight: 400;
+  letter-spacing: 0.01em;
 }
 hr:has(+ h1),
 hr:has(+ h2),
@@ -377,37 +387,39 @@ hr:has(+ h6) {
   margin-top: 3rem;
 }
 
+/* The pixel font renders smaller than the previous heading font at the same
+   size, so sizes are bumped to compensate */
 h1 {
   margin-bottom: 1.75rem;
-  font-family: var(--font-montserrat);
-  font-size: 2rem;
+  font-family: var(--font-pixel);
+  font-size: 2.5rem;
   line-height: 1.2;
 }
 h2 {
   margin-bottom: 1.75rem;
-  font-size: 1.7rem;
+  font-size: 2.1rem;
   line-height: 1.3;
 }
 h3 {
   margin-bottom: 1.75rem;
-  font-size: 1.5rem;
+  font-size: 1.85rem;
   line-height: 1.3;
 }
 h4 {
   margin-bottom: 1.75rem;
-  font-size: 1rem;
+  font-size: 1.25rem;
   line-height: 1.3;
-  letter-spacing: 0.140625em;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
 }
 h5 {
   margin-bottom: 1.75rem;
-  font-size: 0.83255rem;
+  font-size: 1.05rem;
   line-height: 1.1;
 }
 h6 {
   margin-bottom: 1.75rem;
-  font-size: 0.75966rem;
+  font-size: 0.95rem;
   line-height: 1.1;
   font-style: italic;
 }
@@ -579,9 +591,14 @@ hr {
   padding-right: 0;
   padding-top: 0;
   margin-bottom: calc(1.75rem - 1px);
-  background: var(--background-hr);
+  /* Dithered, like a pixel-art separator */
+  background: repeating-linear-gradient(
+    to right,
+    var(--background-hr) 0 5px,
+    transparent 5px 10px
+  );
   border: none;
-  height: 0.5px;
+  height: 1px;
 }
 address {
   margin-left: 0;
@@ -718,4 +735,33 @@ ins {
   color: white;
   padding: 0.10938rem 0.21875rem;
   text-decoration: none;
+}
+
+/* Blinking text cursor, like an old command line waiting for input */
+.blinking-cursor {
+  display: inline-block;
+  margin-left: 0.15em;
+  color: var(--color-accent);
+  animation: blinking-cursor 1.1s step-end infinite;
+  user-select: none;
+
+  @media print {
+    display: none;
+  }
+}
+
+@keyframes blinking-cursor {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .blinking-cursor {
+    animation: none;
+  }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -173,7 +173,7 @@ html {
 body {
   margin: 0;
   color: var(--color-text-body);
-  font-weight: 400;
+  font-weight: 300;
   word-wrap: break-word;
   font-kerning: normal;
   -moz-font-feature-settings: 'kern', 'liga', 'clig', 'calt';
@@ -611,16 +611,16 @@ address {
   margin-bottom: 1.75rem;
 }
 b {
-  font-weight: 600;
+  font-weight: 500;
 }
 strong {
-  font-weight: 600;
+  font-weight: 500;
 }
 dt {
-  font-weight: 600;
+  font-weight: 500;
 }
 th {
-  font-weight: 600;
+  font-weight: 500;
 }
 li {
   margin-bottom: calc(1.75rem / 2);

--- a/app/globals.css
+++ b/app/globals.css
@@ -173,7 +173,7 @@ html {
 body {
   margin: 0;
   color: var(--color-text-body);
-  font-weight: 300;
+  font-weight: 400;
   word-wrap: break-word;
   font-kerning: normal;
   -moz-font-feature-settings: 'kern', 'liga', 'clig', 'calt';
@@ -611,16 +611,16 @@ address {
   margin-bottom: 1.75rem;
 }
 b {
-  font-weight: 500;
+  font-weight: 600;
 }
 strong {
-  font-weight: 500;
+  font-weight: 600;
 }
 dt {
-  font-weight: 500;
+  font-weight: 600;
 }
 th {
-  font-weight: 500;
+  font-weight: 600;
 }
 li {
   margin-bottom: calc(1.75rem / 2);

--- a/app/globals.css
+++ b/app/globals.css
@@ -736,3 +736,32 @@ ins {
   padding: 0.10938rem 0.21875rem;
   text-decoration: none;
 }
+
+/* Blinking text cursor, like an old command line waiting for input */
+.blinking-cursor {
+  display: inline-block;
+  margin-left: 0.15em;
+  color: var(--color-accent);
+  animation: blinking-cursor 1.1s step-end infinite;
+  user-select: none;
+
+  @media print {
+    display: none;
+  }
+}
+
+@keyframes blinking-cursor {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .blinking-cursor {
+    animation: none;
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -736,32 +736,3 @@ ins {
   padding: 0.10938rem 0.21875rem;
   text-decoration: none;
 }
-
-/* Blinking text cursor, like an old command line waiting for input */
-.blinking-cursor {
-  display: inline-block;
-  margin-left: 0.15em;
-  color: var(--color-accent);
-  animation: blinking-cursor 1.1s step-end infinite;
-  user-select: none;
-
-  @media print {
-    display: none;
-  }
-}
-
-@keyframes blinking-cursor {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .blinking-cursor {
-    animation: none;
-  }
-}

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,8 +7,7 @@
   --color-inline-code-text: #e6e6e6;
   --color-shadow: rgba(140, 160, 227, 0.6);
   --color-text-body: rgba(255, 255, 255, 0.88);
-  /* Nods to 90s point-and-click adventures: SCUMM verb green and dialog purple */
-  --color-verb: rgb(140, 220, 150);
+  /* A nod to 90s point-and-click adventures: dialog purple */
   --color-dialog: rgb(180, 120, 200);
   --font-mono: Consolas, Menlo, Monaco, source-code-pro, Courier New, monospace;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import { Plus_Jakarta_Sans, VT323 } from 'next/font/google'
+import { Newsreader, VT323 } from 'next/font/google'
 import Script from 'next/script'
 import { Suspense } from 'react'
 
@@ -11,11 +11,11 @@ import { getSlideAnimationProps } from '#/lib/slide-animation'
 import './globals.css'
 import styles from './layout.module.css'
 
-const jakarta = Plus_Jakarta_Sans({
+// Serif body text designed for on-screen news reading
+const newsreader = Newsreader({
   subsets: ['latin'],
-  weight: ['300', '500'],
   style: ['normal', 'italic'],
-  fallback: ['system-ui', 'sans-serif'],
+  fallback: ['Georgia', 'Times New Roman', 'serif'],
   display: 'swap',
 })
 
@@ -32,7 +32,7 @@ export const metadata = getBaseMetadata()
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className={`${jakarta.className} ${vt323.variable}`}>
+    <html lang="en" className={`${newsreader.className} ${vt323.variable}`}>
       <body>
         <main className={styles.main}>
           <Header />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import { Montserrat, Plus_Jakarta_Sans } from 'next/font/google'
+import { Plus_Jakarta_Sans, VT323 } from 'next/font/google'
 import Script from 'next/script'
 import { Suspense } from 'react'
 
@@ -19,10 +19,12 @@ const jakarta = Plus_Jakarta_Sans({
   display: 'swap',
 })
 
-const montserrat = Montserrat({
+// Pixel display font for a hint of 90s point-and-click adventure nostalgia
+const vt323 = VT323({
   subsets: ['latin'],
-  weight: ['300'],
-  variable: '--font-montserrat',
+  weight: ['400'],
+  variable: '--font-pixel',
+  fallback: ['Courier New', 'monospace'],
   display: 'swap',
 })
 
@@ -30,7 +32,7 @@ export const metadata = getBaseMetadata()
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className={`${jakarta.className} ${montserrat.variable}`}>
+    <html lang="en" className={`${jakarta.className} ${vt323.variable}`}>
       <body>
         <main className={styles.main}>
           <Header />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import { Newsreader, VT323 } from 'next/font/google'
+import { Plus_Jakarta_Sans, VT323 } from 'next/font/google'
 import Script from 'next/script'
 import { Suspense } from 'react'
 
@@ -11,11 +11,11 @@ import { getSlideAnimationProps } from '#/lib/slide-animation'
 import './globals.css'
 import styles from './layout.module.css'
 
-// Serif body text designed for on-screen news reading
-const newsreader = Newsreader({
+const jakarta = Plus_Jakarta_Sans({
   subsets: ['latin'],
+  weight: ['300', '500'],
   style: ['normal', 'italic'],
-  fallback: ['Georgia', 'Times New Roman', 'serif'],
+  fallback: ['system-ui', 'sans-serif'],
   display: 'swap',
 })
 
@@ -32,7 +32,7 @@ export const metadata = getBaseMetadata()
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className={`${newsreader.className} ${vt323.variable}`}>
+    <html lang="en" className={`${jakarta.className} ${vt323.variable}`}>
       <body>
         <main className={styles.main}>
           <Header />

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -1,6 +1,8 @@
 .label {
   display: block;
-  font-size: 0.85rem; /* Match subtitle */
+  font-family: var(--font-pixel);
+  font-size: 1.05rem;
+  letter-spacing: 0.1em;
   color: var(--color-accent);
   margin-bottom: 1rem;
   opacity: 0.85;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import { ExternalLink } from '#/components/ExternalLink'
 import { FeaturedVideo } from '#/components/FeaturedVideo'
 import { HugeHeading } from '#/components/HugeHeading'
+import { TypewriterPhrase } from '#/components/TypewriterPhrase'
 import { TALKS } from '#/content/talks'
 
 import styles from './page.module.css'
@@ -8,8 +9,19 @@ import styles from './page.module.css'
 export default function Home() {
   return (
     <>
-      <HugeHeading>
-        Hey, I’m Kenneth. I’m a software engineer, 2x dad, and music nerd.
+      <HugeHeading aria-label="Hey, I’m Kenneth. I’m a software engineer, 2x dad, and music nerd.">
+        <span aria-hidden="true">
+          Hey, I’m Kenneth. I’m a software engineer, 2x dad, and{' '}
+          <TypewriterPhrase
+            phrases={[
+              'music nerd.',
+              'sourdough feeder.',
+              'pizza baker.',
+              'kombucha feeder.',
+              'vinyl digger.',
+            ]}
+          />
+        </span>
       </HugeHeading>
       <p style={{ marginTop: '2rem' }}>
         Based in Copenhagen, Denmark. Currently building{' '}

--- a/components/Header.module.css
+++ b/components/Header.module.css
@@ -37,18 +37,25 @@
 }
 
 .navLink {
-  font-size: 16px;
+  font-family: var(--font-pixel);
+  font-size: 20px;
+  letter-spacing: 0.02em;
   opacity: 0.5;
   text-decoration: none;
-  transition: opacity 0.2s ease;
+  transition:
+    opacity 0.2s ease,
+    color 0.2s ease;
 }
 
+/* Highlight like a hovered verb in a point-and-click interface */
 .navLinkActive {
   opacity: 0.9;
+  color: var(--color-verb);
 }
 
 .navLink:hover {
   opacity: 1;
+  color: var(--color-verb);
 }
 
 .siteName {
@@ -57,6 +64,7 @@
 
 .siteName:hover {
   opacity: 1 !important;
+  color: white;
 }
 
 .showOnMobile {

--- a/components/Header.module.css
+++ b/components/Header.module.css
@@ -49,13 +49,13 @@
 
 /* Highlight like a hovered verb in a point-and-click interface */
 .navLinkActive {
-  opacity: 0.9;
-  color: var(--color-verb);
+  opacity: 1;
+  color: var(--color-accent);
 }
 
 .navLink:hover {
   opacity: 1;
-  color: var(--color-verb);
+  color: var(--color-accent);
 }
 
 .siteName {

--- a/components/HugeHeading.tsx
+++ b/components/HugeHeading.tsx
@@ -2,14 +2,7 @@ export function HugeHeading(props: {
   children: React.ReactNode
   style?: React.CSSProperties
 }) {
-  return (
-    <h1 style={{ marginTop: '1.3rem', ...props.style }}>
-      {props.children}
-      <span className="blinking-cursor" aria-hidden="true">
-        ▌
-      </span>
-    </h1>
-  )
+  return <h1 style={{ marginTop: '1.3rem', ...props.style }}>{props.children}</h1>
 }
 
 export function EmptyTopSpace() {

--- a/components/HugeHeading.tsx
+++ b/components/HugeHeading.tsx
@@ -1,8 +1,13 @@
 export function HugeHeading(props: {
   children: React.ReactNode
   style?: React.CSSProperties
+  'aria-label'?: string
 }) {
-  return <h1 style={{ marginTop: '1.3rem', ...props.style }}>{props.children}</h1>
+  return (
+    <h1 style={{ marginTop: '1.3rem', ...props.style }} aria-label={props['aria-label']}>
+      {props.children}
+    </h1>
+  )
 }
 
 export function EmptyTopSpace() {

--- a/components/HugeHeading.tsx
+++ b/components/HugeHeading.tsx
@@ -2,7 +2,14 @@ export function HugeHeading(props: {
   children: React.ReactNode
   style?: React.CSSProperties
 }) {
-  return <h1 style={{ marginTop: '1.3rem', ...props.style }}>{props.children}</h1>
+  return (
+    <h1 style={{ marginTop: '1.3rem', ...props.style }}>
+      {props.children}
+      <span className="blinking-cursor" aria-hidden="true">
+        ▌
+      </span>
+    </h1>
+  )
 }
 
 export function EmptyTopSpace() {

--- a/components/TypewriterPhrase.tsx
+++ b/components/TypewriterPhrase.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+const holdDelayMs = 2800
+const typingDelayMs = 90
+const deletingDelayMs = 45
+const nextPhraseDelayMs = 500
+
+export function TypewriterPhrase({ phrases }: { phrases: string[] }) {
+  const [phraseIndex, setPhraseIndex] = useState(0)
+  const [charCount, setCharCount] = useState(phrases[0]?.length ?? 0)
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [isAnimating, setIsAnimating] = useState(false)
+
+  useEffect(() => {
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      return
+    }
+    setIsAnimating(true)
+  }, [])
+
+  useEffect(() => {
+    if (!isAnimating) {
+      return
+    }
+
+    const phrase = phrases[phraseIndex] ?? ''
+    let timeout: ReturnType<typeof setTimeout>
+    if (isDeleting) {
+      if (charCount === 0) {
+        timeout = setTimeout(() => {
+          setPhraseIndex((phraseIndex + 1) % phrases.length)
+          setIsDeleting(false)
+        }, nextPhraseDelayMs)
+      } else {
+        timeout = setTimeout(() => setCharCount(charCount - 1), deletingDelayMs)
+      }
+    } else if (charCount === phrase.length) {
+      timeout = setTimeout(() => setIsDeleting(true), holdDelayMs)
+    } else {
+      timeout = setTimeout(() => setCharCount(charCount + 1), typingDelayMs)
+    }
+    return () => clearTimeout(timeout)
+  }, [isAnimating, phrases, phraseIndex, charCount, isDeleting])
+
+  return (
+    <>
+      {(phrases[phraseIndex] ?? '').slice(0, charCount)}
+      <span className="blinking-cursor" aria-hidden="true">
+        ▌
+      </span>
+    </>
+  )
+}


### PR DESCRIPTION
## What

Gives the site a subtle nod to 90s LucasArts point-and-click adventures (Monkey Island, Day of the Tentacle) — a hint of nostalgia, not a costume. The background color and the Plus Jakarta Sans body text are unchanged.

## Changes

- **Pixel display font**: Headings, nav, and small-caps labels now use [VT323](https://fonts.google.com/specimen/VT323) — a high-quality digitization of the DOS-era terminal font, very readable at display sizes. It replaces Montserrat (OG images keep their local Montserrat files). Heading sizes are bumped slightly to compensate for the narrower pixel glyphs.
- **Typewriter landing heading**: on the home page, a blinking block cursor deletes "music nerd." and types out other hats (sourdough feeder, pizza baker, kombucha feeder, vinyl digger) on a loop. Blog headings stay static. Screen readers get a static `aria-label`, and the animation is disabled under `prefers-reduced-motion`.
- **Verb-style nav**: nav links are set in the pixel font like a point-and-click verb bar, highlighting in the site's periwinkle accent on hover/active to match post titles and labels.
- **DOS dialog boxes**: code blocks and inline code get square corners and a subtly bluish border.
- **Dithered separators**: `hr` is now a dashed, pixel-dither-style line.
- **Dialog purple selection**: `::selection` uses a Monkey-Island-dialog purple; focus outlines are dotted, DOS style.

A serif body font (Newsreader) was tried and reverted — the branch history keeps both commits if it's ever wanted back.

## Screenshots

Verified with Playwright on desktop (1280px) and mobile (390px) across the home page, blog index, and blog posts (including code blocks). The typewriter cycle was verified by sampling the heading text over 22 seconds. Text remains readable throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GEFCgiEbJ3gnYhyWV9Gd76